### PR TITLE
feat: add nvm role for managing Node.js versions

### DIFF
--- a/group_vars/semgrep.yml
+++ b/group_vars/semgrep.yml
@@ -68,6 +68,11 @@ zsh_functions:
 zsh_variables:
   AWS_PROFILE: engineer
 
+nvm_versions:
+  18.17.0:
+  20.19.5:
+    global: true
+
 homebrew_taps:
   semgrep/infra:
     url: git@github.com:semgrep/homebrew-infra.git

--- a/main.yml
+++ b/main.yml
@@ -18,6 +18,11 @@
     - role: rbenv
       tags: ["rbenv"]
 
+- hosts: node
+  roles:
+    - role: nvm
+      tags: ["nvm"]
+
 - hosts: go
   roles:
     - role: go

--- a/roles/nvm/defaults/main.yml
+++ b/roles/nvm/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+nvm_dir: "{{ ansible_env.HOME }}/.nvm"
+
+nvm_versions: {}

--- a/roles/nvm/meta/main.yml
+++ b/roles/nvm/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: zsh

--- a/roles/nvm/tasks/install.yml
+++ b/roles/nvm/tasks/install.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: macos/install.yml
+  when: ansible_os_family == 'Darwin'

--- a/roles/nvm/tasks/macos/install.yml
+++ b/roles/nvm/tasks/macos/install.yml
@@ -1,0 +1,15 @@
+---
+- name: Ensuring nvm is installed
+  homebrew:
+    name: nvm
+    state: latest
+
+- name: Get Homebrew prefix
+  command:
+    cmd: "brew --prefix"
+  register: brew_prefix_result
+  changed_when: False
+
+- name: Set nvm install path
+  set_fact:
+    nvm_install_path: "{{ brew_prefix_result.stdout }}/opt/nvm"

--- a/roles/nvm/tasks/main.yml
+++ b/roles/nvm/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- include_tasks: install.yml
+
+- name: Installing node versions
+  command: bash -c ". {{ nvm_install_path }}/nvm.sh && nvm install {{ item.version }}"
+  args:
+    creates: "{{ nvm_dir }}/versions/node/v{{ item.version }}"
+  loop: "{{ nvm_versions | dict2items(key_name='version', value_name='config') }}"
+
+- name: Setting default node version
+  command: bash -c ". {{ nvm_install_path }}/nvm.sh && nvm alias default {{ item.version }}"
+  loop: "{{ nvm_versions | dict2items(key_name='version', value_name='config') | rejectattr('config', 'none') | selectattr('config.global', 'equalto', true) }}"
+  changed_when: false
+
+- name: Enabling nvm in ZSH
+  template:
+    src: zshrc.d/nvm.j2
+    dest: "{{ zshrc_dir }}/nvm"

--- a/roles/nvm/templates/zshrc.d/nvm.j2
+++ b/roles/nvm/templates/zshrc.d/nvm.j2
@@ -1,0 +1,3 @@
+export NVM_DIR="{{ nvm_dir }}"
+[ -s "{{ nvm_install_path }}/nvm.sh" ] && \. "{{ nvm_install_path }}/nvm.sh"  # This loads nvm
+[ -s "{{ nvm_install_path }}/etc/bash_completion.d/nvm" ] && \. "{{ nvm_install_path }}/etc/bash_completion.d/nvm"  # This loads nvm bash_completion

--- a/semgrep.ini
+++ b/semgrep.ini
@@ -7,6 +7,9 @@ semgrep-mac
 [python]
 semgrep-mac
 
+[node]
+semgrep-mac
+
 [go]
 semgrep-mac
 


### PR DESCRIPTION
## Summary

- Adds an `nvm` role following the same pattern as `pyenv`/`rbenv`: installs via Homebrew, resolves the install path from `brew --prefix` as a fact, and writes an nvm snippet to `zshrc.d/`
- Supports installing Node versions and setting a global default via `nvm_versions` vars (same `global: true` convention as pyenv)
- Adds a `node` host group to the main playbook and enables the role for the semgrep inventory with Node 18.17.0 and 20.19.5 (global default)