### PR TITLE
Trust third-party homebrew forumlae/casks

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -10,11 +10,27 @@
     url: "{{ item.config.url | default(omit) }}"
   loop: "{{ homebrew_taps | dict2items(key_name='name', value_name='config') }}"
 
+- name: Trust Third-Party Formulae
+  ansible.builtin.command:
+    cmd: "brew trust --formula {{ item.name }}"
+  loop: "{{ homebrew_formulae | dict2items(key_name='name', value_name='config') }}"
+  when: "'/' in item.name"
+  register: trust_formula
+  changed_when: "trust_formula.stdout.startswith('Trusted ')"
+
 - name: Install Formulae
   homebrew:
     name: "{{ item.name }}"
     state: "{{ item.config.state | default('present') }}"
   loop: "{{ homebrew_formulae | dict2items(key_name='name', value_name='config') }}"
+
+- name: Trust Third-Party Casks
+  ansible.builtin.command:
+    cmd: "brew trust --cask {{ item.name }}"
+  loop: "{{ homebrew_casks | dict2items(key_name='name', value_name='config') }}"
+  when: "'/' in item.name"
+  register: trust_cask
+  changed_when: "trust_cask.stdout.startswith('Trusted ')"
 
 - name: Install Casks
   homebrew_cask:


### PR DESCRIPTION
Homebrew now requires explicit trust for things that aren't part of the built-in taps. Rather than broadly trusting the whole tap, trust individual formulae or casks. 