### PR TITLE
feat: add worktrunk ansible role

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -7,6 +7,8 @@
       tags: ["git"]
     - role: direnv
       tags: ["direnv"]
+    - role: worktrunk
+      tags: ["worktrunk"]
 
 - hosts: python
   roles:

--- a/roles/worktrunk/meta/main.yml
+++ b/roles/worktrunk/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: zsh

--- a/roles/worktrunk/tasks/install.yml
+++ b/roles/worktrunk/tasks/install.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: macos/install.yml
+  when: ansible_os_family == 'Darwin'

--- a/roles/worktrunk/tasks/macos/install.yml
+++ b/roles/worktrunk/tasks/macos/install.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensuring worktrunk is installed
+  homebrew:
+    name: worktrunk
+    state: latest

--- a/roles/worktrunk/tasks/main.yml
+++ b/roles/worktrunk/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- include_tasks: install.yml
+
+- name: Enabling worktrunk in ZSH
+  template:
+    src: zshrc.d/worktrunk.j2
+    dest: "{{ zshrc_dir }}/worktrunk"

--- a/roles/worktrunk/templates/zshrc.d/worktrunk.j2
+++ b/roles/worktrunk/templates/zshrc.d/worktrunk.j2
@@ -1,0 +1,3 @@
+if [ -x "$(command -v wt)" ]; then
+    eval "$(wt config shell init zsh)"
+fi


### PR DESCRIPTION
## Why

The `worktrunk` CLI (binary `wt`) was installed ad-hoc — the tool via Homebrew plus a hand-written `~/.zshrc.d/wt` snippet — so the setup wasn't repeatable. This captures it as a proper role.

## What

- Add `roles/worktrunk/` mirroring the `direnv`/`pyenv` pattern: Homebrew install (`worktrunk`, homebrew-core, no tap) + a `~/.zshrc.d/worktrunk` snippet rendered from a template. Depends on the `zsh` role.
- The snippet reproduces the existing `~/.zshrc.d/wt` init (`eval "$(wt config shell init zsh)"`); the binary stays `wt`.
- Enable it in the existing `all` group in `main.yml`, alongside `git` and `direnv`.

## Validation

- `ansible-playbook -i semgrep.ini main.yml --syntax-check` passes.
- Run to apply: `ansible-playbook -i semgrep.ini main.yml --tags worktrunk -K` (the `-K` covers the shared `zsh` dependency's shell-change task).
- After applying, manually remove the now-superseded `~/.zshrc.d/wt`.

---
_🤖 Generated by Claude_